### PR TITLE
Fix issue#1

### DIFF
--- a/pyrtools/SCFpyr.py
+++ b/pyrtools/SCFpyr.py
@@ -41,10 +41,6 @@ class SCFpyr(SFpyr):
         else:
             order = int(order)
 
-        # if order % 2 == 0:
-        #     raise ValueError("order (number of orientations) could not be "
-        #                      "even-number because of unknown bug.")
-
         nbands = order + 1
 
         self.order = order

--- a/pyrtools/SCFpyr.py
+++ b/pyrtools/SCFpyr.py
@@ -41,9 +41,9 @@ class SCFpyr(SFpyr):
         else:
             order = int(order)
 
-        if order % 2 == 0:
-            raise ValueError("order (number of orientations) could not be "
-                             "even-number because of unknown bug.")
+        # if order % 2 == 0:
+        #     raise ValueError("order (number of orientations) could not be "
+        #                      "even-number because of unknown bug.")
 
         nbands = order + 1
 
@@ -141,7 +141,7 @@ class SCFpyr(SFpyr):
                                     Xcosn[0] + numpy.pi * b / nbands,
                                     Xcosn[1] - Xcosn[0], 0)
                 anglemask = anglemask.reshape(lodft.shape[0], lodft.shape[1])
-                banddft = (cmath.sqrt(-1)**order) * lodft * anglemask * himask
+                banddft = (cmath.sqrt(-1)**order) * lodft * anglemask * himask * (-1+order%2*2)
                 band = numpy.negative(numpy.fft.ifft2(
                     numpy.fft.ifftshift(banddft)))
                 self.pyr.append(band.copy())


### PR DESCRIPTION
I added ±1 factor to banddft. The factor is -1 if order is even.
In my environment, it's going well. (conda 4.3.24, ubuntu 16.04)
I tested the case of order from 3 to 10.

```python
scfpyr = pyrtools.SCFPyr(img, 4, 4)
scfpyr.reconPyr()
```
![figure_1](https://user-images.githubusercontent.com/4953729/29320223-7a03bad2-8211-11e7-8e27-85c5db55b5df.png)
